### PR TITLE
scroll to given cell index

### DIFF
--- a/Demo/UI/Main/MainView.swift
+++ b/Demo/UI/Main/MainView.swift
@@ -9,6 +9,8 @@ class MainView: UIView {
   
   // MARK: - UIElements
   
+  private let button = UIButton()
+  
   lazy var collection: UICollectionView = {
     let carouselFlow = UICollectionViewCarouselLayout()
     carouselFlow.itemSize = CGSize(width: DemoCell.width, height: DemoCell.height)
@@ -42,13 +44,18 @@ class MainView: UIView {
   
   func configure() {
     addSubview(collection)
+    addSubview(button)
+    
     collection.dataSource = self
     collection.delegate = self
+    
+    button.addTarget(self, action: #selector(scrollToCell), for: .touchUpInside)
   }
   
   func style() {
     backgroundColor = .white
-    
+    button.setTitle("scroll to random cell", for: .normal)
+    button.setTitleColor(.blue, for: .normal)
     collection.backgroundColor = .clear
     collection.showsHorizontalScrollIndicator = false
   }
@@ -61,6 +68,21 @@ class MainView: UIView {
     collection.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
     collection.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
     collection.heightAnchor.constraint(equalToConstant: 300).isActive = true
+    
+    button.translatesAutoresizingMaskIntoConstraints = false
+    button.topAnchor.constraint(equalTo: collection.bottomAnchor, constant: 40).isActive = true
+    button.centerXAnchor.constraint(equalTo: collection.centerXAnchor).isActive = true
+    button.heightAnchor.constraint(equalToConstant: 40).isActive = true
+  }
+}
+
+// MARK: - Action
+
+extension MainView {
+  @objc func scrollToCell() {
+    let randomInt = Int.random(in: 0..<8)
+    print("scroll to cell \(randomInt)")
+    collection.scrollToCell(at: randomInt)
   }
 }
 

--- a/Sources/ToosieSlide/UICollectionView+Extensions.swift
+++ b/Sources/ToosieSlide/UICollectionView+Extensions.swift
@@ -45,6 +45,8 @@ public extension UICollectionView {
     carouselFlowLayout.currentVisibleCellIndex = index
     // navigate to offset
     setContentOffset(CGPoint(x: finalOffset, y: contentOffset.y), animated: animated)
+    // update the layout
+    carouselFlowLayout.invalidateLayout()
   }
   
   /// Returns the visible cell object at the specified `CellIndex`.

--- a/Sources/ToosieSlide/UICollectionView+Extensions.swift
+++ b/Sources/ToosieSlide/UICollectionView+Extensions.swift
@@ -40,7 +40,7 @@ public extension UICollectionView {
     // make sure index don't overflow
     let index = min(index, numberOfItems(inSection: 0) - 1)
     // get new offset
-    let finalOffset = carouselFlowLayout.currentOffset + CGFloat(index) * (carouselFlowLayout.itemSize.width + carouselFlowLayout.minimumLineSpacing)
+    let finalOffset = CGFloat(index) * (carouselFlowLayout.itemSize.width + carouselFlowLayout.minimumLineSpacing)
     // update visible cell
     carouselFlowLayout.currentVisibleCellIndex = index
     // navigate to offset


### PR DESCRIPTION
- remove carouselFlowLayout.currentOffset from the calculation of the final offset when scrolling to a given cell index.
- added a button to generate random number between 0 and the number of collection data items and scroll to it